### PR TITLE
Fixed mac address creation for worker nodes and disk creation

### DIFF
--- a/talos-boot.tf
+++ b/talos-boot.tf
@@ -87,7 +87,7 @@ resource "talos_machine_configuration_apply" "worker-nodes" {
     })
   ],
     [
-      for disk in var.worker_nodes[each.key].data_disks : templatefile(
+      for disk in each.value.data_disks : templatefile(
       "${path.module}/talos-config/worker-node-disk.yaml.tpl",
       {
         disk_device = "/dev/${disk.device_name}",

--- a/vm-worker-node.tf
+++ b/vm-worker-node.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 resource "macaddress" "talos-worker-node" {
-  count = length(local.vm_control_planes)
+  count = length(local.vm_worker_nodes)
 }
 
 resource "proxmox_virtual_environment_vm" "talos-worker-node" {


### PR DESCRIPTION
Awesome that you made this btw!

When deploying my cluster I ran into a couple issues.

1) Iterating `data_disks`, instead of getting the key to access the value I had to change it to access it directly. There was a key error I was running into. I don't have the log anymore though.

2) I noticed that the mac address creation for worker nodes was based on the control_planes count. Fixed that.
```
╷
│ Error: Invalid index
│
│   on vm-worker-node.tf line 55, in resource "proxmox_virtual_environment_vm" "talos-worker-node":
│   55:     mac_address = macaddress.talos-worker-node[each.key].address
│     ├────────────────
│     │ each.key is "3"
│     │ macaddress.talos-worker-node is tuple with 3 elements
│
│ The given key does not identify an element in this collection value: the given index is greater than or equal to the length of the collection.
```